### PR TITLE
De 105 hubspot v3 export hubspot urls to their respective tables

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -97,8 +97,11 @@ class HubspotStream(RESTStream):
         Returns row, or None if row is to be excluded"""
 
         if self.replication_key:
+            print("POST PROCESS")
+            print(row)
             if utils.strptime_to_utc(row[self.replication_key]) < self.get_starting_timestamp(context).astimezone(pytz.utc):
                 return None
+        print("WAS CLEARED")
         return row
 
     def get_json_schema(self, from_type: str) -> dict:

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -97,11 +97,8 @@ class HubspotStream(RESTStream):
         Returns row, or None if row is to be excluded"""
 
         if self.replication_key:
-            print("POST PROCESS")
-            print(row)
             if utils.strptime_to_utc(row[self.replication_key]) < self.get_starting_timestamp(context).astimezone(pytz.utc):
                 return None
-        print("WAS CLEARED")
         return row
 
     def get_json_schema(self, from_type: str) -> dict:

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -85,23 +85,6 @@ class DealsStream(HubspotStream):
         if self.cached_schema is None:
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
-
-class DealsStream(HubspotStream):
-    """Define custom stream."""
-    name = "deals"
-    path = "/crm/v3/objects/deals"
-    primary_keys = ["id"]
-
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
-        params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        return params
-
-    @property
-    def schema(self) -> dict:
-        if self.cached_schema is None:
-            self.cached_schema, self.properties = self.get_custom_schema()
-        return self.cached_schema
 class ContactsStream(HubspotStream):
     """Define custom stream."""
     name = "contacts"

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -86,6 +86,39 @@ class DealsStream(HubspotStream):
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
 
+class DealsStream(HubspotStream):
+    """Define custom stream."""
+    name = "deals"
+    path = "/crm/v3/objects/deals"
+    primary_keys = ["id"]
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['properties'] = ','.join(self.properties)
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema()
+        return self.cached_schema
+class ContactsStream(HubspotStream):
+    """Define custom stream."""
+    name = "contacts"
+    path = "/crm/v3/objects/contacts"
+    primary_keys = ["id"]
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['properties'] = ','.join(self.properties)
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema()
+        return self.cached_schema
+
 class PropertiesStream(HubspotStream):
     """Define custom stream."""
     schema_filepath = SCHEMAS_DIR / "properties.json"

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -6,6 +6,7 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 from tap_hubspot.streams import (
+    ContactsStream ,
     CompaniesStream,
     DealsStream,
     MeetingsStream,
@@ -17,6 +18,7 @@ from tap_hubspot.streams import (
 )
 
 STREAM_TYPES = [
+    ContactsStream,
     CompaniesStream,
     DealsStream,
     MeetingsStream,


### PR DESCRIPTION
# What was the issue
Wanted to create url to hubspot ressource to make it easier for marketing to directly access a resource

# How did we solve it
A url for a resource follows this format: `https://app.hubspot.com/contacts/{portalId}/{objectType}/{objectId}` where our portalID is always the same (2851660). We therefore only needed to provide this information + add contacts to the available pool of information 

# Additional Notes / Warnings


# Fun fact (optional)
