### PR TITLE
DE-197 Hubspot_v3 - Add a field for primary company associated to a deal

### DIFF
--- a/tap_hubspot/schemas/associations_deals_companies.json
+++ b/tap_hubspot/schemas/associations_deals_companies.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "properties":{
+        "id": ["null", "string"],
+        "toObjectId": {
+            "type": ["null","integer"]
+        },
+        "associationTypes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": ["null", "string"]
+                    },
+                    "typeId": {
+                        "type": ["null", "integer"]
+                    },
+                    "label": {
+                        "type": ["null", "string"]
+                    }
+                }
+            }
+        }
+    }
+  }

--- a/tap_hubspot/schemas/associations_deals_companies.json
+++ b/tap_hubspot/schemas/associations_deals_companies.json
@@ -1,11 +1,12 @@
 {
-    "type": "object",
+    "type": ["object", "null"],
     "properties":{
-        "id": ["null", "string"],
+        "id": {
+            "type": ["null","string"]
+        },
         "toObjectId": {
             "type": ["null","integer"]
-        },
-        "associationTypes": {
+        },  "associationTypes": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -24,3 +25,4 @@
         }
     }
   }
+

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -133,9 +133,9 @@ class PropertiesContactsStream(PropertiesStream):
     path = "/crm/v3/properties/contacts"
 
 
-class AssociationsStream(HubspotStream):
+class AssociationsDealsToCompaniesStream(HubspotStream):
     name="associations_deals_companies"
-    path = "/crm/v4/objects/deals/{id}/associations/companies"
+    path = "/crm/v4/objects/deals/{deal_id}/associations/companies"
 
     parent_stream_type = DealsStream
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -136,10 +136,29 @@ class PropertiesContactsStream(PropertiesStream):
 class AssociationsDealsToCompaniesStream(HubspotStream):
     name="associations_deals_companies"
     path = "/crm/v4/objects/deals/{deal_id}/associations/companies"
-
+    deal_id = ""
     parent_stream_type = DealsStream
 
     ignore_parent_replication_keys = True
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params = super().get_url_params(context, next_page_token)
+        self.deal_id = context['deal_id']
+        return params
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        data = response.json()['results']
+        ret = []
+        for e in data:
+            elem = e
+            elem['id'] = self.deal_id
+            ret.append(elem)
+
+
+        return ret
 
 
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -85,6 +85,12 @@ class DealsStream(HubspotStream):
         if self.cached_schema is None:
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "deal_id": record["id"],
+        }
 class ContactsStream(HubspotStream):
     """Define custom stream."""
     name = "contacts"

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -127,7 +127,13 @@ class PropertiesContactsStream(PropertiesStream):
     path = "/crm/v3/properties/contacts"
 
 
+class AssociationsStream(HubspotStream):
+    name="associations_deals_companies"
+    path = "/crm/v4/objects/deals/{id}/associations/companies"
 
+    parent_stream_type = DealsStream
+
+    ignore_parent_replication_keys = True
 
 
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -137,6 +137,8 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     name="associations_deals_companies"
     path = "/crm/v4/objects/deals/{deal_id}/associations/companies"
     deal_id = ""
+    replication_method = "FULL_TABLE"
+    replication_key = ""
     parent_stream_type = DealsStream
 
     ignore_parent_replication_keys = True

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -6,6 +6,7 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 from tap_hubspot.streams import (
+    AssociationsDealsToCompaniesStream,
     ContactsStream ,
     CompaniesStream,
     DealsStream,
@@ -18,6 +19,7 @@ from tap_hubspot.streams import (
 )
 
 STREAM_TYPES = [
+    AssociationsDealsToCompaniesStream,
     ContactsStream,
     CompaniesStream,
     DealsStream,


### PR DESCRIPTION
### Ticket ([DE-197](https://potloc.atlassian.net/browse/DE-197))

> We can have multiple companies associated to a deal (or an engagement) and in the front end there will be a mark for the primary one. That’s the one we want to use systematically but in GBQ we don’t have a distinction like that. 
> 
> Is it possible to add a _primary_ field inside of the array or a _primary_associated_company_ field in properties?
---
_from `tiguidou` with :heart:_

### Goal
Create associations table between deals and companies

### How
Implement parent-child relationship between deals and associations to use the id from the deal to make our query

