### PR TITLE
DE-220 Hubspot_v3 - Get archived elements

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -150,7 +150,7 @@ class HubspotStream(RESTStream):
                 return jsonschema_type
         return sqltype_lookup["string"]  # safe failover to str
 
-    def get_custom_schema(self, name = "", poorly_cast: List[str] = []):
+    def get_custom_schema(self, name:str = None, poorly_cast: List[str] = []):
         """Dynamically detect the json schema for the stream.
         This is evaluated prior to any records being retrieved.
 
@@ -159,10 +159,7 @@ class HubspotStream(RESTStream):
         internal_properties: List[th.Property] = []
         properties: List[th.Property] = []
 
-        if name == "":
-            properties_hub = self.get_properties()
-        else:
-            properties_hub = self.get_properties(name=name)
+        properties_hub = self.get_properties(n=name)
         params = []
 
         for prop in properties_hub:
@@ -183,7 +180,10 @@ class HubspotStream(RESTStream):
             ))
         return th.PropertiesList(*properties).to_dict(), params
 
-    def get_properties(self, name: str="") -> List[dict]:
+    def get_properties(self, n: str=None) -> List[dict]:
+        name = n
+        if n is None:
+            name = self.name
         response = requests.get(f"{self.url_base}/crm/v3/properties/{name}", headers=self.http_headers)
         res = response.json()
         return res['results']

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -150,7 +150,7 @@ class HubspotStream(RESTStream):
                 return jsonschema_type
         return sqltype_lookup["string"]  # safe failover to str
 
-    def get_custom_schema(self, poorly_cast: List[str] = []):
+    def get_custom_schema(self, name = "", poorly_cast: List[str] = []):
         """Dynamically detect the json schema for the stream.
         This is evaluated prior to any records being retrieved.
 
@@ -159,8 +159,10 @@ class HubspotStream(RESTStream):
         internal_properties: List[th.Property] = []
         properties: List[th.Property] = []
 
-
-        properties_hub = self.get_properties()
+        if name == "":
+            properties_hub = self.get_properties()
+        else:
+            properties_hub = self.get_properties(name=name)
         params = []
 
         for prop in properties_hub:
@@ -181,8 +183,8 @@ class HubspotStream(RESTStream):
             ))
         return th.PropertiesList(*properties).to_dict(), params
 
-    def get_properties(self) -> List[dict]:
-        response = requests.get(f"{self.url_base}/crm/v3/properties/{self.name}", headers=self.http_headers)
+    def get_properties(self, name: str="") -> List[dict]:
+        response = requests.get(f"{self.url_base}/crm/v3/properties/{name}", headers=self.http_headers)
         res = response.json()
         return res['results']
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -29,69 +29,6 @@ utc=pytz.UTC
 
 
 
-class ArchivedCompaniesStream(HubspotStream):
-    """Define custom stream."""
-    name = "archived_companies"
-    schema_filepath = SCHEMAS_DIR / "companies.json"
-    path = "/crm/v3/objects/companies"
-    primary_keys = ["id"]
-
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
-        params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        params['archived'] = True
-        return params
-
-    @property
-    def schema(self) -> dict:
-        if self.cached_schema is None:
-            self.cached_schema, self.properties = self.get_custom_schema(name = "companies")
-        return self.cached_schema
-
-class ArchivedContactsStream(HubspotStream):
-    """Define custom stream."""
-    name = "archived_contacts"
-    schema_filepath = SCHEMAS_DIR / "contacts.json"
-    path = "/crm/v3/objects/contacts"
-    primary_keys = ["id"]
-
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
-        params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        params['archived'] = True
-        return params
-
-    @property
-    def schema(self) -> dict:
-        if self.cached_schema is None:
-            self.cached_schema, self.properties = self.get_custom_schema(name = "contacts")
-        return self.cached_schema
-
-class ArchivedDealsStream(HubspotStream):
-    """Define custom stream."""
-    name = "archived_deals"
-    schema_filepath = SCHEMAS_DIR / "deals.json"
-    path = "/crm/v3/objects/deals"
-    primary_keys = ["id"]
-
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
-        params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        params['archived'] = True
-        return params
-
-    @property
-    def schema(self) -> dict:
-        if self.cached_schema is None:
-            self.cached_schema, self.properties = self.get_custom_schema(name = "deals")
-        return self.cached_schema
-
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a context dictionary for child streams."""
-        return {
-            "deal_id": record["id"],
-        }
-
 class MeetingsStream(HubspotStream):
     name = "meetings"
     path = f"/crm/v3/objects/meetings"
@@ -131,6 +68,22 @@ class CompaniesStream(HubspotStream):
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
 
+class ArchivedCompaniesStream(CompaniesStream):
+    """Define custom stream."""
+    name = "archived_companies"
+    schema_filepath = ""
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['archived'] = True
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema(name="companies")
+        return self.cached_schema
+
 class DealsStream(HubspotStream):
     """Define custom stream."""
     name = "deals"
@@ -153,6 +106,23 @@ class DealsStream(HubspotStream):
         return {
             "deal_id": record["id"],
         }
+
+class ArchivedDealsStream(DealsStream):
+    """Define custom stream."""
+    name = "archived_deals"
+    schema_filepath = ""
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['archived'] = True
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema(name = "deals")
+        return self.cached_schema
+
 class ContactsStream(HubspotStream):
     """Define custom stream."""
     name = "contacts"
@@ -169,6 +139,25 @@ class ContactsStream(HubspotStream):
         if self.cached_schema is None:
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
+
+class ArchivedContactsStream(ContactsStream):
+    """Define custom stream."""
+    name = "archived_contacts"
+    schema_filepath = ""
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['archived'] = True
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema(name = "contacts")
+        return self.cached_schema
+
+
+
 
 class PropertiesStream(HubspotStream):
     """Define custom stream."""

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -29,6 +29,68 @@ utc=pytz.UTC
 
 
 
+class ArchivedCompaniesStream(HubspotStream):
+    """Define custom stream."""
+    name = "archived_companies"
+    schema_filepath = SCHEMAS_DIR / "companies.json"
+    path = "/crm/v3/objects/companies"
+    primary_keys = ["id"]
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['properties'] = ','.join(self.properties)
+        params['archived'] = True
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema(name = "companies")
+        return self.cached_schema
+
+class ArchivedContactsStream(HubspotStream):
+    """Define custom stream."""
+    name = "archived_contacts"
+    schema_filepath = SCHEMAS_DIR / "contacts.json"
+    path = "/crm/v3/objects/contacts"
+    primary_keys = ["id"]
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['properties'] = ','.join(self.properties)
+        params['archived'] = True
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema(name = "contacts")
+        return self.cached_schema
+
+class ArchivedDealsStream(HubspotStream):
+    """Define custom stream."""
+    name = "archived_deals"
+    schema_filepath = SCHEMAS_DIR / "deals.json"
+    path = "/crm/v3/objects/deals"
+    primary_keys = ["id"]
+
+    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params['properties'] = ','.join(self.properties)
+        params['archived'] = True
+        return params
+
+    @property
+    def schema(self) -> dict:
+        if self.cached_schema is None:
+            self.cached_schema, self.properties = self.get_custom_schema(name = "deals")
+        return self.cached_schema
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "deal_id": record["id"],
+        }
 
 class MeetingsStream(HubspotStream):
     name = "meetings"

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -6,6 +6,9 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 from tap_hubspot.streams import (
+    ArchivedCompaniesStream,
+    ArchivedContactsStream,
+    ArchivedDealsStream,
     AssociationsDealsToCompaniesStream,
     ContactsStream ,
     CompaniesStream,
@@ -19,6 +22,9 @@ from tap_hubspot.streams import (
 )
 
 STREAM_TYPES = [
+    ArchivedCompaniesStream,
+    ArchivedContactsStream,
+    ArchivedDealsStream,
     AssociationsDealsToCompaniesStream,
     ContactsStream,
     CompaniesStream,


### PR DESCRIPTION
### Ticket ([DE-220](https://potloc.atlassian.net/browse/DE-220))

> With dbt, we can create an _is archived_ flag to filter by deleted entries. This should remove our issue of deprecated values in Hubspot 
> 
> *Goal*
> 
> Introduce the archived equivalents to companies, deals and contacts
> 
> *Why*
> 
> To perform a version of soft delete, where we remove deleted entities (in the source) from the table that contains all the data (since meltano does not perform deletions in bigquery)
> 
> *In the future*
> 
> Using dbt to take snapshot and drop table: [https://medium.com/@danielpdwalker/handling-hard-deleted-data-from-source-5578e67f5a0c](https://medium.com/@danielpdwalker/handling-hard-deleted-data-from-source-5578e67f5a0c|smart-link) 

---
_from `tiguidou` with :heart:_
