### PR TITLE
DE-231 Hubspot_v3 - Associations to deals duplicate entries 

### DIFF
--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -162,6 +162,7 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     path = "/crm/v4/objects/deals/{deal_id}/associations/companies"
     deal_id = ""
     replication_method = "FULL_TABLE"
+    primary_keys = ["id", "toObjectId"]
     replication_key = ""
     parent_stream_type = DealsStream
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -163,6 +163,7 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
+    state_partitioning_keys = []
     replication_key = ""
     parent_stream_type = DealsStream
 

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -20,17 +20,17 @@ from tap_hubspot.streams import (
 
 STREAM_TYPES = [
     AssociationsDealsToCompaniesStream,
-    # ContactsStream,
-    # CompaniesStream,
+    ContactsStream,
+    CompaniesStream,
     DealsStream,
-    # MeetingsStream,
+    MeetingsStream,
 
-    # PropertiesCompaniesStream,
-    # PropertiesContactsStream,
-    # PropertiesDealsStream,
-    # PropertiesMeetingsStream,
+    PropertiesCompaniesStream,
+    PropertiesContactsStream,
+    PropertiesDealsStream,
+    PropertiesMeetingsStream,
 
-    # OwnersStream,
+    OwnersStream,
 ]
 
 

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -20,17 +20,17 @@ from tap_hubspot.streams import (
 
 STREAM_TYPES = [
     AssociationsDealsToCompaniesStream,
-    ContactsStream,
-    CompaniesStream,
+    # ContactsStream,
+    # CompaniesStream,
     DealsStream,
-    MeetingsStream,
+    # MeetingsStream,
 
-    PropertiesCompaniesStream,
-    PropertiesContactsStream,
-    PropertiesDealsStream,
-    PropertiesMeetingsStream,
+    # PropertiesCompaniesStream,
+    # PropertiesContactsStream,
+    # PropertiesDealsStream,
+    # PropertiesMeetingsStream,
 
-    OwnersStream,
+    # OwnersStream,
 ]
 
 


### PR DESCRIPTION
### Ticket ([DE-231](https://potloc.atlassian.net/browse/DE-231))

> > select distinct id, count(id) over (partition by id) as test, count(distinct(toobjectid)) over (partition by id) as nb_asso_companies
> > from `potloc-165719.hubspot_v3.associations_deals_companies`
> > left join unnest(associationtypes) as asso
> > order by 3 desc
> 
> *What*
> 
> Duplicate entries in the `associations_deals_companies` table => Inheritance doing some cycles
> 
> 
> 
> *Also*
> 
> Add `where asso.value.label="Primary"` and we have 2 companies where there are 2 primary comapnies but that is false
> 
> 
> 
> *Idea*
> 
> We just introduced archived true/false; could this be causing an issue?

---
_from `tiguidou` with :heart:_
