### PR TITLE
DE-350 Tap-Hubspot - Typo in workflows_v3

### DIFF
--- a/tap_hubspot/automation_streams.py
+++ b/tap_hubspot/automation_streams.py
@@ -49,7 +49,7 @@ class AutomationStream(HubspotStream):
         return row
 
 class WorkflowsStream(AutomationStream):
-    name = "wokrflows_v3"
+    name = "workflows_v3"
     path = "/automation/v3/workflows"
     primary_keys = ["id"]
     schema = Workflows.schema


### PR DESCRIPTION
### Ticket ([DE-350](https://potloc.atlassian.net/browse/DE-350))

> Table name is `wokrflows_v3`-> should be `workflows_v3`

---
_from `tiguidou` with :heart:_
