### PR TITLE
DE-411 Fix Hubspot's table association_contact_deals 

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -16,7 +16,7 @@ plugins:
     - name: start_date
       value: '2010-01-01T00:00:00Z'
     config:
-      start_date: '2022-08-17T00:00:00Z'
+      value: '2010-01-01T00:00:00Z'
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano.yml
+++ b/meltano.yml
@@ -16,7 +16,7 @@ plugins:
     - name: start_date
       value: '2010-01-01T00:00:00Z'
     config:
-      value: '2010-01-01T00:00:00Z'
+      start_date: '2010-01-01T00:00:00Z'
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano.yml
+++ b/meltano.yml
@@ -16,7 +16,7 @@ plugins:
     - name: start_date
       value: '2010-01-01T00:00:00Z'
     config:
-      start_date: '2010-01-01T00:00:00Z'
+      start_date: '2022-08-17T00:00:00Z'
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -115,7 +115,7 @@ class DealsStream(HubspotStream):
 class ContactsStream(HubspotStream):
     """Define custom stream."""
 
-    name = "contacts"
+    name = "contacts_2"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
@@ -238,7 +238,7 @@ class AssociationsContactsToDealsStream(HubspotStream):
     name = "associations_contacts_deals_2"
     path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
     deal_id = ""
-    replication_method = "INCREMENTAL"
+    replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
     state_partitioning_keys = []
     replication_key = ""

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -118,7 +118,6 @@ class ContactsStream(HubspotStream):
     name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]
-    replication_method = "FULL_TABLE"
     partitions = [{"archived": True}, {"archived": False}]
 
     def get_url_params(
@@ -236,26 +235,25 @@ class AssociationsDealsToContactsStream(HubspotStream):
 
 
 class AssociationsContactsToDealsStream(HubspotStream):
-    contact_id = 37341901
     name = "associations_contacts_deals"
-    path = "/crm/v4/objects/contacts/37341901/associations/deals"
+    path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
     state_partitioning_keys = []
     replication_key = ""
-    # parent_stream_type = ContactsStream
+    parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
     ignore_parent_replication_keys = True
 
-    # def get_url_params(
-    #     self, context: Optional[dict], next_page_token: Optional[Any]
-    # ) -> Dict[str, Any]:
-    #     """Return a dictionary of values to be used in URL parameterization."""
-    #     params = super().get_url_params(context, next_page_token)
-    #     self.contact_id = context["contact_id"]
-    #     return params
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params = super().get_url_params(context, next_page_token)
+        self.contact_id = context["contact_id"]
+        return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         data = response.json()["results"]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -245,7 +245,7 @@ class AssociationsContactsToDealsStream(HubspotStream):
     parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = True
+    ignore_parent_replication_keys = False
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -181,7 +181,7 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = True
+    ignore_parent_replication_keys = False
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -213,7 +213,7 @@ class AssociationsDealsToContactsStream(HubspotStream):
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = True
+    ignore_parent_replication_keys = False
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -277,7 +277,7 @@ class AssociationsContactsToCompaniesStream(HubspotStream):
     parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = True
+    ignore_parent_replication_keys = False
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -309,7 +309,7 @@ class AssociationsCompaniesToContactsStream(HubspotStream):
     parent_stream_type = CompaniesStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = True
+    ignore_parent_replication_keys = False
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -341,7 +341,7 @@ class AssociationsCompaniesToDealsStream(HubspotStream):
     parent_stream_type = CompaniesStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = True
+    ignore_parent_replication_keys = False
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -235,26 +235,25 @@ class AssociationsDealsToContactsStream(HubspotStream):
 
 
 class AssociationsContactsToDealsStream(HubspotStream):
-    contact_id = "37341901"
     name = "associations_contacts_deals"
-    path = "/crm/v4/objects/contacts/37341901/associations/deals"
+    path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
     state_partitioning_keys = []
     replication_key = ""
-    # parent_stream_type = ContactsStream
+    parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
     ignore_parent_replication_keys = True
 
-    # def get_url_params(
-    #     self, context: Optional[dict], next_page_token: Optional[Any]
-    # ) -> Dict[str, Any]:
-    #     """Return a dictionary of values to be used in URL parameterization."""
-    #     params = super().get_url_params(context, next_page_token)
-    #     self.contact_id = context["contact_id"]
-    #     return params
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params = super().get_url_params(context, next_page_token)
+        self.contact_id = context["contact_id"]
+        return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         data = response.json()["results"]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -115,7 +115,7 @@ class DealsStream(HubspotStream):
 class ContactsStream(HubspotStream):
     """Define custom stream."""
 
-    name = "contacts_2"
+    name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
@@ -235,7 +235,7 @@ class AssociationsDealsToContactsStream(HubspotStream):
 
 
 class AssociationsContactsToDealsStream(HubspotStream):
-    name = "associations_contacts_deals_2"
+    name = "associations_contacts_deals"
     path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
     deal_id = ""
     replication_method = "FULL_TABLE"

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -235,10 +235,10 @@ class AssociationsDealsToContactsStream(HubspotStream):
 
 
 class AssociationsContactsToDealsStream(HubspotStream):
-    name = "associations_contacts_deals"
+    name = "associations_contacts_deals_2"
     path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
     deal_id = ""
-    replication_method = "FULL_TABLE"
+    replication_method = "INCREMENTAL"
     primary_keys = ["id", "toObjectId"]
     state_partitioning_keys = []
     replication_key = ""

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -118,6 +118,7 @@ class ContactsStream(HubspotStream):
     name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]
+    replication_method = "FULL_TABLE"
     partitions = [{"archived": True}, {"archived": False}]
 
     def get_url_params(
@@ -235,25 +236,26 @@ class AssociationsDealsToContactsStream(HubspotStream):
 
 
 class AssociationsContactsToDealsStream(HubspotStream):
+    contact_id = 37341901
     name = "associations_contacts_deals"
-    path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
+    path = "/crm/v4/objects/contacts/37341901/associations/deals"
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
     state_partitioning_keys = []
     replication_key = ""
-    parent_stream_type = ContactsStream
+    # parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
     ignore_parent_replication_keys = True
 
-    def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Dict[str, Any]:
-        """Return a dictionary of values to be used in URL parameterization."""
-        params = super().get_url_params(context, next_page_token)
-        self.contact_id = context["contact_id"]
-        return params
+    # def get_url_params(
+    #     self, context: Optional[dict], next_page_token: Optional[Any]
+    # ) -> Dict[str, Any]:
+    #     """Return a dictionary of values to be used in URL parameterization."""
+    #     params = super().get_url_params(context, next_page_token)
+    #     self.contact_id = context["contact_id"]
+    #     return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         data = response.json()["results"]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -25,8 +25,7 @@ from tap_hubspot.client import HubspotStream
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 LOGGER = singer.get_logger()
-utc=pytz.UTC
-
+utc = pytz.UTC
 
 
 class MeetingsStream(HubspotStream):
@@ -34,9 +33,11 @@ class MeetingsStream(HubspotStream):
     path = f"/crm/v3/objects/meetings"
     primary_keys = ["id"]
 
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
+        params["properties"] = ",".join(self.properties)
         return params
 
     @property
@@ -45,23 +46,29 @@ class MeetingsStream(HubspotStream):
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
 
+
 class OwnersStream(HubspotStream):
     """Define custom stream."""
+
     name = "owners"
     path = "/crm/v3/owners"
     primary_keys = ["id"]
 
+
 class CompaniesStream(HubspotStream):
     """Define custom stream."""
+
     name = "companies"
     path = "/crm/v3/objects/companies"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        params['archived'] = context['archived']
+        params["properties"] = ",".join(self.properties)
+        params["archived"] = context["archived"]
         return params
 
     @property
@@ -70,26 +77,25 @@ class CompaniesStream(HubspotStream):
             self.cached_schema, self.properties = self.get_custom_schema()
         return self.cached_schema
 
-
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return {
-            "archived": record["archived"],
-            "company_id": record["id"]
-        }
+        return {"archived": record["archived"], "company_id": record["id"]}
 
 
 class DealsStream(HubspotStream):
     """Define custom stream."""
+
     name = "deals"
     path = "/crm/v3/objects/deals"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        params['archived'] = context['archived']
+        params["properties"] = ",".join(self.properties)
+        params["archived"] = context["archived"]
         return params
 
     @property
@@ -106,18 +112,20 @@ class DealsStream(HubspotStream):
         }
 
 
-
 class ContactsStream(HubspotStream):
     """Define custom stream."""
+
     name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params['properties'] = ','.join(self.properties)
-        params['archived'] = context['archived']
+        params["properties"] = ",".join(self.properties)
+        params["archived"] = context["archived"]
         return params
 
     @property
@@ -128,31 +136,34 @@ class ContactsStream(HubspotStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return {
-            "archived": record["archived"],
-            "contact_id": record["id"]
-        }
+        return {"archived": record["archived"], "contact_id": record["id"]}
 
 
 class PropertiesStream(HubspotStream):
     """Define custom stream."""
+
     schema_filepath = SCHEMAS_DIR / "properties.json"
     primary_keys = ["name"]
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         return [x for x in data if self.replication_key in x]
+
+
 class PropertiesDealsStream(PropertiesStream):
     name = "properties_deals"
     path = "/crm/v3/properties/deals"
+
 
 class PropertiesMeetingsStream(PropertiesStream):
     name = "properties_meetings"
     path = "/crm/v3/properties/meetings"
 
+
 class PropertiesCompaniesStream(PropertiesStream):
     name = "properties_companies"
     path = "/crm/v3/properties/companies"
+
 
 class PropertiesContactsStream(PropertiesStream):
     name = "properties_contacts"
@@ -160,7 +171,7 @@ class PropertiesContactsStream(PropertiesStream):
 
 
 class AssociationsDealsToCompaniesStream(HubspotStream):
-    name="associations_deals_companies"
+    name = "associations_deals_companies"
     path = "/crm/v4/objects/deals/{deal_id}/associations/companies"
     deal_id = ""
     replication_method = "FULL_TABLE"
@@ -177,23 +188,22 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        self.deal_id = context['deal_id']
+        self.deal_id = context["deal_id"]
         return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         ret = []
         for e in data:
             elem = e
-            elem['id'] = self.deal_id
+            elem["id"] = self.deal_id
             ret.append(elem)
-
 
         return ret
 
 
 class AssociationsDealsToContactsStream(HubspotStream):
-    name="associations_deals_contacts"
+    name = "associations_deals_contacts"
     path = "/crm/v4/objects/deals/{deal_id}/associations/contacts"
     deal_id = ""
     replication_method = "FULL_TABLE"
@@ -203,7 +213,6 @@ class AssociationsDealsToContactsStream(HubspotStream):
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-
     ignore_parent_replication_keys = True
 
     def get_url_params(
@@ -211,54 +220,55 @@ class AssociationsDealsToContactsStream(HubspotStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        self.deal_id = context['deal_id']
+        self.deal_id = context["deal_id"]
         return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         ret = []
         for e in data:
             elem = e
-            elem['id'] = self.deal_id
+            elem["id"] = self.deal_id
             ret.append(elem)
-
 
         return ret
 
+
 class AssociationsContactsToDealsStream(HubspotStream):
-    name="associations_contacts_deals"
-    path = "/crm/v4/objects/contacts/{contact_id}/associations/deals"
+    contact_id = "37341901"
+    name = "associations_contacts_deals"
+    path = "/crm/v4/objects/contacts/37341901/associations/deals"
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
     state_partitioning_keys = []
     replication_key = ""
-    parent_stream_type = ContactsStream
+    # parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
     ignore_parent_replication_keys = True
 
-    def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Dict[str, Any]:
-        """Return a dictionary of values to be used in URL parameterization."""
-        params = super().get_url_params(context, next_page_token)
-        self.contact_id = context['contact_id']
-        return params
+    # def get_url_params(
+    #     self, context: Optional[dict], next_page_token: Optional[Any]
+    # ) -> Dict[str, Any]:
+    #     """Return a dictionary of values to be used in URL parameterization."""
+    #     params = super().get_url_params(context, next_page_token)
+    #     self.contact_id = context["contact_id"]
+    #     return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         ret = []
         for e in data:
             elem = e
-            elem['id'] = self.contact_id
+            elem["id"] = self.contact_id
             ret.append(elem)
-
 
         return ret
 
+
 class AssociationsContactsToCompaniesStream(HubspotStream):
-    name="associations_contacts_companies"
+    name = "associations_contacts_companies"
     path = "/crm/v4/objects/contacts/{contact_id}/associations/companies"
     deal_id = ""
     replication_method = "FULL_TABLE"
@@ -275,22 +285,22 @@ class AssociationsContactsToCompaniesStream(HubspotStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        self.contact_id = context['contact_id']
+        self.contact_id = context["contact_id"]
         return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         ret = []
         for e in data:
             elem = e
-            elem['id'] = self.contact_id
+            elem["id"] = self.contact_id
             ret.append(elem)
-
 
         return ret
 
+
 class AssociationsCompaniesToContactsStream(HubspotStream):
-    name="associations_companies_contacts"
+    name = "associations_companies_contacts"
     path = "/crm/v4/objects/companies/{company_id}/associations/contacts"
     deal_id = ""
     replication_method = "FULL_TABLE"
@@ -307,22 +317,22 @@ class AssociationsCompaniesToContactsStream(HubspotStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        self.company_id = context['company_id']
+        self.company_id = context["company_id"]
         return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         ret = []
         for e in data:
             elem = e
-            elem['id'] = self.company_id
+            elem["id"] = self.company_id
             ret.append(elem)
-
 
         return ret
 
+
 class AssociationsCompaniesToDealsStream(HubspotStream):
-    name="associations_companies_deals"
+    name = "associations_companies_deals"
     path = "/crm/v4/objects/companies/{company_id}/associations/deals"
     deal_id = ""
     replication_method = "FULL_TABLE"
@@ -339,16 +349,15 @@ class AssociationsCompaniesToDealsStream(HubspotStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        self.company_id = context['company_id']
+        self.company_id = context["company_id"]
         return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        data = response.json()['results']
+        data = response.json()["results"]
         ret = []
         for e in data:
             elem = e
-            elem['id'] = self.company_id
+            elem["id"] = self.company_id
             ret.append(elem)
-
 
         return ret

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -55,7 +55,7 @@ STREAM_TYPES = [
     # AssociationsDealsToContactsStream,
     # ContactsStream,
     # CompaniesStream,
-    # ContactsStream,
+    ContactsStream,
     # DealsStream,
     # MeetingsStream,
     # PropertiesCompaniesStream,

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -1,6 +1,7 @@
 """Hubspot tap class."""
 
 from typing import List
+
 # from black import main
 
 from singer_sdk import Tap, Stream
@@ -12,7 +13,7 @@ from tap_hubspot.streams import (
     AssociationsContactsToDealsStream,
     AssociationsDealsToCompaniesStream,
     AssociationsDealsToContactsStream,
-    ContactsStream ,
+    ContactsStream,
     CompaniesStream,
     DealsStream,
     MeetingsStream,
@@ -32,7 +33,7 @@ from tap_hubspot.marketing_streams import (
 
 from tap_hubspot.events_streams import (
     WebAnalyticsContactsStream,
-    WebAnalyticsDealsStream
+    WebAnalyticsDealsStream,
 )
 
 from tap_hubspot.analytics_streams import (
@@ -46,43 +47,40 @@ from tap_hubspot.automation_streams import (
 
 STREAM_TYPES = [
     ## CRM
-    AssociationsCompaniesToContactsStream,
-    AssociationsCompaniesToDealsStream,
-    AssociationsContactsToCompaniesStream,
+    # AssociationsCompaniesToContactsStream,
+    # AssociationsCompaniesToDealsStream,
+    # AssociationsContactsToCompaniesStream,
     AssociationsContactsToDealsStream,
-    AssociationsDealsToCompaniesStream,
-    AssociationsDealsToContactsStream,
-    ContactsStream,
-    CompaniesStream,
-    ContactsStream,
-    DealsStream,
-    MeetingsStream,
-    PropertiesCompaniesStream,
-    PropertiesContactsStream,
-    PropertiesDealsStream,
-    PropertiesMeetingsStream,
-    OwnersStream,
-
-    ## Marketing
-    MarketingEmailsStream,
-    MarketingCampaignIdsStream,
-    MarketingCampaignsStream,
-    MarketingFormsStream,
-
-    # Events
-    WebAnalyticsContactsStream,
-    WebAnalyticsDealsStream,
-
-    ## Analytics
-    AnalyticsViewsStream,
-
-    ## Automation
-    WorkflowsStream
+    # AssociationsDealsToCompaniesStream,
+    # AssociationsDealsToContactsStream,
+    # ContactsStream,
+    # CompaniesStream,
+    # ContactsStream,
+    # DealsStream,
+    # MeetingsStream,
+    # PropertiesCompaniesStream,
+    # PropertiesContactsStream,
+    # PropertiesDealsStream,
+    # PropertiesMeetingsStream,
+    # OwnersStream,
+    # ## Marketing
+    # MarketingEmailsStream,
+    # MarketingCampaignIdsStream,
+    # MarketingCampaignsStream,
+    # MarketingFormsStream,
+    # # Events
+    # WebAnalyticsContactsStream,
+    # WebAnalyticsDealsStream,
+    # ## Analytics
+    # AnalyticsViewsStream,
+    # ## Automation
+    # WorkflowsStream,
 ]
 
 
 class TapHubspot(Tap):
     """Hubspot tap class."""
+
     name = "tap-hubspot"
 
     config_jsonschema = th.PropertiesList(
@@ -96,13 +94,14 @@ class TapHubspot(Tap):
             "start_date",
             th.DateTimeType,
             required=True,
-            description="The earliest record date to sync"
-        )
+            description="The earliest record date to sync",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
         return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+
 
 if __name__ == "__main__":
     TapHubspot.cli()

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -55,7 +55,7 @@ STREAM_TYPES = [
     # AssociationsDealsToContactsStream,
     # ContactsStream,
     # CompaniesStream,
-    ContactsStream,
+    # ContactsStream,
     # DealsStream,
     # MeetingsStream,
     # PropertiesCompaniesStream,

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -47,34 +47,34 @@ from tap_hubspot.automation_streams import (
 
 STREAM_TYPES = [
     ## CRM
-    # AssociationsCompaniesToContactsStream,
-    # AssociationsCompaniesToDealsStream,
-    # AssociationsContactsToCompaniesStream,
+    AssociationsCompaniesToContactsStream,
+    AssociationsCompaniesToDealsStream,
+    AssociationsContactsToCompaniesStream,
     AssociationsContactsToDealsStream,
-    # AssociationsDealsToCompaniesStream,
-    # AssociationsDealsToContactsStream,
-    # ContactsStream,
-    # CompaniesStream,
-    # ContactsStream,
-    # DealsStream,
-    # MeetingsStream,
-    # PropertiesCompaniesStream,
-    # PropertiesContactsStream,
-    # PropertiesDealsStream,
-    # PropertiesMeetingsStream,
-    # OwnersStream,
-    # ## Marketing
-    # MarketingEmailsStream,
-    # MarketingCampaignIdsStream,
-    # MarketingCampaignsStream,
-    # MarketingFormsStream,
-    # # Events
-    # WebAnalyticsContactsStream,
-    # WebAnalyticsDealsStream,
-    # ## Analytics
-    # AnalyticsViewsStream,
-    # ## Automation
-    # WorkflowsStream,
+    AssociationsDealsToCompaniesStream,
+    AssociationsDealsToContactsStream,
+    ContactsStream,
+    CompaniesStream,
+    ContactsStream,
+    DealsStream,
+    MeetingsStream,
+    PropertiesCompaniesStream,
+    PropertiesContactsStream,
+    PropertiesDealsStream,
+    PropertiesMeetingsStream,
+    OwnersStream,
+    ## Marketing
+    MarketingEmailsStream,
+    MarketingCampaignIdsStream,
+    MarketingCampaignsStream,
+    MarketingFormsStream,
+    # Events
+    WebAnalyticsContactsStream,
+    WebAnalyticsDealsStream,
+    ## Analytics
+    AnalyticsViewsStream,
+    ## Automation
+    WorkflowsStream,
 ]
 
 


### PR DESCRIPTION
### Ticket ([DE-411](https://potloc.atlassian.net/browse/DE-411))

> Recent change in Hubspot doesn’t appear in the database. They have recently add contact_level but we can’t see the value in our db => linked to association tables which were created a week ago

---
_from `tiguidou` with :heart:_
