### PR TITLE
DE-506 Investigate table associations_deals_companies

### DIFF
--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -176,7 +176,7 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
-    state_partitioning_keys = []
+    state_partitioning_keys = ["id"]
     replication_key = ""
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
@@ -208,7 +208,7 @@ class AssociationsDealsToContactsStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
-    state_partitioning_keys = []
+    state_partitioning_keys = ["id"]
     replication_key = ""
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
@@ -240,7 +240,7 @@ class AssociationsContactsToDealsStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
-    state_partitioning_keys = []
+    state_partitioning_keys = ["id"]
     replication_key = ""
     parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
@@ -272,7 +272,7 @@ class AssociationsContactsToCompaniesStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
-    state_partitioning_keys = []
+    state_partitioning_keys = ["id"]
     replication_key = ""
     parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
@@ -304,7 +304,7 @@ class AssociationsCompaniesToContactsStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
-    state_partitioning_keys = []
+    state_partitioning_keys = ["id"]
     replication_key = ""
     parent_stream_type = CompaniesStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
@@ -336,7 +336,7 @@ class AssociationsCompaniesToDealsStream(HubspotStream):
     deal_id = ""
     replication_method = "FULL_TABLE"
     primary_keys = ["id", "toObjectId"]
-    state_partitioning_keys = []
+    state_partitioning_keys = ["id"]
     replication_key = ""
     parent_stream_type = CompaniesStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -181,7 +181,7 @@ class AssociationsDealsToCompaniesStream(HubspotStream):
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = False
+    ignore_parent_replication_keys = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -213,7 +213,7 @@ class AssociationsDealsToContactsStream(HubspotStream):
     parent_stream_type = DealsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = False
+    ignore_parent_replication_keys = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -277,7 +277,7 @@ class AssociationsContactsToCompaniesStream(HubspotStream):
     parent_stream_type = ContactsStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = False
+    ignore_parent_replication_keys = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -309,7 +309,7 @@ class AssociationsCompaniesToContactsStream(HubspotStream):
     parent_stream_type = CompaniesStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = False
+    ignore_parent_replication_keys = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -341,7 +341,7 @@ class AssociationsCompaniesToDealsStream(HubspotStream):
     parent_stream_type = CompaniesStream
     schema_filepath = SCHEMAS_DIR / "associations_all.json"
 
-    ignore_parent_replication_keys = False
+    ignore_parent_replication_keys = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]


### PR DESCRIPTION
Set `ignore_parent_replication_key` to false: Makes child stream independant from parent
Set partitionning key: Allows for bookmark to only be dependent on the id (and not the toObjectId) 

### Ticket ([DE-506](https://potloc.atlassian.net/browse/DE-506))

> Hey Stéphane \!
> 
> Gil a remarqué qu’il y avait des valeurs nulles dans [ce dashboard](https://datastudio.google.com/s/tVLFpmaffgQ) et m’a demandé d’investiguer. 
> 
> J’ai remarqué une erreur dans mon code au niveau des parentids que j’ai reglée, mais il me restait encore des erreurs. 
> 
> J’allais t’envoyer un Slack mais j’ai remarqué d’autres choses bizarres sur cette table donc je t’en fais un ticket 🙂 
> 
> 1st issue : 
> 
> J’ai l’impression que le sync de la table est pas mal décalé par rapport aux autres tables hubspot, et c’est problématique parce que certains nouveaux deals ont des companies nulles (comme la table a pas encore register la relation entre deal et company). 
> 
> C’est peut être pas une question de sync parce que certains deals/companies se sync, mais la majorité des cas où je voyais company=null dans [ce dashboard](https://datastudio.google.com/s/tVLFpmaffgQ) concernait des deals récents (deal close date entre le 8 et le 13 septembre).
> 
> Dans ce cas là, on a aucune correspondance dans la table pour les dealids en question 
> 
> 2nd issue :  
> 
> En fouillant un peu plus je suis tombé sur ce [deal ](https://app.hubspot.com/contacts/2851660/deal/7643857206)qui date de janvier 2022 : si tu regardes dans la table il a deux companies en primary, ce qui est impossible (c’est pas le cas dans le front end en tout cas).
> 
> Est ce que tu vois quelque chose de ton côté qui expliquerait ça? 
> 
> 3rd issue : 
> 
> Dans le même deal que le deuxième point on a 2 primary associated companies, et [un des deux companyid](https://app.hubspot.com/contacts/2851660/company/7716165252) (toobjectid) dans la table ne correspond pas à la compagnie sur hubspot ([Inc-Query USA](https://app.hubspot.com/contacts/2851660/company/7716129616)). 
> 
> Du coup pour ce deal là, non seulement il y a 2 primary companies alors qu’il devrait y en avoir une, mais celle que mon code retient est celle qui ne mène nulle part. 
> 
> Ci-dessous le code pour le deal en question : 
> 
> {code:sql}select d.id as dealid, 
>   a.id as asso_dealid, 
>   a.toObjectId as asso_companyid,
>   c.id as companyid, 
>   a.association_types_label
> from `potloc-data.dbt_hubspot.stg_hubspot_deals` d
> left join `potloc-data.dbt_hubspot.stg_hubspot_associations_deals_companies` a on d.id=a.id
> left join `potloc-data.dbt_hubspot.stg_hubspot_companies` c on c.id=a.toobjectid
> where d.id="7643857206"```
> 
> Hésite pas à m’appeller si t’as des questions,
> 
> Merci 

---
_from `tiguidou` with :heart:_
