### PR TITLE
feat: Add `activityType` and `teamId` attributes to engagements stream.

### DIFF
--- a/tap_hubspot/schemas/engagements.json
+++ b/tap_hubspot/schemas/engagements.json
@@ -37,6 +37,12 @@
         "timestamp": {
           "type": ["null", "integer"],
           "format": "date-time"
+        },
+        "activityType": {
+          "type": ["null","string"]
+        },
+        "teamId": {
+          "type": ["null","string"]
         }
       }
     },


### PR DESCRIPTION
# What was the issue
Without these fields it's not possible breakdown Hubspot calls, meetings and email by the type of activity or the team responsible for the activity.

# How did we solve it
Updated the engagements schema.

# Additional Notes / Warnings
We've been using this updated schema for over year based on a fork of this repo: https://github.com/singer-io/tap-hubspot

# Fun fact (optional)
I got nothing, sorry 😬 .