### PR TITLE
Fix error due to large properties set

### DIFF
--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -113,10 +113,16 @@ class DealsStream(HubspotStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
-        params["archived"] = context["archived"]
-        return params
+   
+        all_properties = self.properties
 
+        chunks = self.get_properties_chunks(all_properties, 300)
+        for chunk in chunks:
+            params["properties"] = ",".join(chunk)
+            params["archived"] = context["archived"]
+        
+            yield params
+    
     @property
     def schema(self) -> dict:
         if self.cached_schema is None:
@@ -143,9 +149,15 @@ class ContactsStream(HubspotStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
-        params["archived"] = context["archived"]
-        return params
+
+        all_properties = self.properties
+
+        chunks = self.get_properties_chunks(all_properties, 500)
+        for chunk in chunks:
+            params["properties"] = ",".join(chunk)
+            params["archived"] = context["archived"]
+          
+            yield params
 
     @property
     def schema(self) -> dict:


### PR DESCRIPTION

# What was the issue
When the list of properties is too large the API raises <FatalAPI ERROR 400>. In my case the list contained around 1500 properties.

# How did we solve it
To fix this issue some of the methods in the main HubspotStream class were overwritten to cover such cases by returning a generator instead of the whole list. This way all the properties are passed in batches.

# Additional Notes / Warnings
-

# Fun fact (optional)
-