### PR TITLE
fix: gracefully continue with warning if dynamic discovery fails

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -179,12 +179,16 @@ class HubspotStream(RESTStream):
 
     def get_properties(self) -> List[dict]:
         response = requests.get(f"{self.url_base}/crm/v3/properties/{self.name}", headers=self.http_headers)
-        res = response.json()
-
         try:
-            return res["results"]
-        except KeyError:
-            raise KeyError(f"Error retrieving the API query results: {res}")
+            res = response.json()
+            response.raise_for_status()
+            return res.get("results", [])
+        except requests.exceptions.HTTPError as e:
+            LOGGER.warning(
+                "Dynamic discovery of properties failed with an exception, "
+                f"continuing gracefully with no dynamic properties: {e}, {res}"
+            )
+            return []
 
     def get_params_from_properties(self, properties: List[dict]) -> List[str]:
         params = []


### PR DESCRIPTION
# What was the issue

An issue came up in the Meltano slack https://meltano.slack.com/archives/C01TCRBBJD7/p1683310751290039 where the user doesnt have the scopes for all streams in the tap. They were trying to use selection to only extract from the streams they did have access to but since the discovery process errors unless you have proper permissions, they werent able to get to the point where those streams could be filtered out. 

# How did we solve it

Meltano runs `--discover`, alters the catalog based on selection rules, then passes it to the tap for syncing. This PR allows the discovery step to succeed even if dynamic schema discovery fails. It logs a warning with with the error response text and continues. Ultimately the user gets a catalog entry for that stream with only the default properties like `updatedAt`, `createdAt`, etc.

# Additional Notes / Warnings

I think its good to allow users to only sync their selected set of streams but I wonder if theres any side affects of this if a discovery fails on an incremental sync when the user expects it to pass. The first sync has a bunch of dynamically discovered properties then the second sync had a failed discovery step (maybe an API issue) that causes the second stream to only sync the default keys, everything else is null in the destination for those records.

@SBurwash @edgarrmondragon what do you think about this tradeoff?

# Fun fact (optional)
