### PR TITLE
DE-1717 Hubspot - Create replace existing associations tables for companies, contacts & deals with new version of the API

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -166,6 +166,32 @@ class HubspotStream(RESTStream):
         properties.append(th.Property('createdAt', th.DateTimeType()))
         properties.append(th.Property('id', th.StringType()))
         properties.append(th.Property('archived', th.BooleanType()))
+        properties.append(th.Property('associations', th.ObjectType(
+            th.Property("companies", th.ObjectType(
+                th.Property("results", th.ArrayType(
+                    th.ObjectType(
+                        th.Property("id", th.StringType()),
+                        th.Property("type", th.StringType())
+                    )
+                ))
+            )),
+            th.Property("contacts", th.ObjectType(
+                th.Property("results", th.ArrayType(
+                    th.ObjectType(
+                        th.Property("id", th.StringType()),
+                        th.Property("type", th.StringType())
+                    )
+                ))
+            )),
+            th.Property("deals", th.ObjectType(
+                th.Property("results", th.ArrayType(
+                    th.ObjectType(
+                        th.Property("id", th.StringType()),
+                        th.Property("type", th.StringType())
+                    )
+                ))
+            ))
+        )))
         properties.append(th.Property(
                 'properties', th.ObjectType(*internal_properties)
             ))

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -166,32 +166,34 @@ class HubspotStream(RESTStream):
         properties.append(th.Property('createdAt', th.DateTimeType()))
         properties.append(th.Property('id', th.StringType()))
         properties.append(th.Property('archived', th.BooleanType()))
-        properties.append(th.Property('associations', th.ObjectType(
-            th.Property("companies", th.ObjectType(
-                th.Property("results", th.ArrayType(
-                    th.ObjectType(
-                        th.Property("id", th.StringType()),
-                        th.Property("type", th.StringType())
-                    )
-                ))
-            )),
-            th.Property("contacts", th.ObjectType(
-                th.Property("results", th.ArrayType(
-                    th.ObjectType(
-                        th.Property("id", th.StringType()),
-                        th.Property("type", th.StringType())
-                    )
-                ))
-            )),
-            th.Property("deals", th.ObjectType(
-                th.Property("results", th.ArrayType(
-                    th.ObjectType(
-                        th.Property("id", th.StringType()),
-                        th.Property("type", th.StringType())
-                    )
+        properties.append(
+            th.Property('associations', th.ObjectType(
+                th.Property("companies", th.ObjectType(
+                    th.Property("results", th.ArrayType(
+                        th.ObjectType(
+                            th.Property("id", th.StringType()),
+                            th.Property("type", th.StringType())
+                        )
+                    ))
+                )),
+                th.Property("contacts", th.ObjectType(
+                    th.Property("results", th.ArrayType(
+                        th.ObjectType(
+                            th.Property("id", th.StringType()),
+                            th.Property("type", th.StringType())
+                        )
+                    ))
+                )),
+                th.Property("deals", th.ObjectType(
+                    th.Property("results", th.ArrayType(
+                        th.ObjectType(
+                            th.Property("id", th.StringType()),
+                            th.Property("type", th.StringType())
+                        )
+                    ))
                 ))
             ))
-        )))
+        )
         properties.append(th.Property(
                 'properties', th.ObjectType(*internal_properties)
             ))

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -132,8 +132,16 @@ class DealsStream(HubspotStream):
         }
     
     def parse_response(self, response) -> Iterable[dict]:
-        self.logger.info(response.json()["results"])
+        data = response.json()["results"]
+        for e in data:
+            self.logger.info("response")
+            self.logger.info(e.get("associations", ""))
         return super().parse_response(response)
+
+    def post_process(self, row: dict, context: dict | None) -> dict:
+        self.logger.info("post_process")
+        self.logger.info(row)
+        return super().post_process(row, context)
 
 
 class ContactsStream(HubspotStream):

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -102,7 +102,6 @@ class CompaniesStream(HubspotStream):
 
 class DealsStream(HubspotStream):
     """Define custom stream."""
-    _LOG_REQUEST_METRICS_URL=True
     name = "deals"
     path = "/crm/v3/objects/deals"
     primary_keys = ["id"]
@@ -112,7 +111,7 @@ class DealsStream(HubspotStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        # params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
         params["associations"] = "contacts,companies,deals"
         self.logger.info(params)

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -86,6 +86,7 @@ class CompaniesStream(HubspotStream):
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
+        params["associations"] = "contacts,companies,deals"
         return params
 
     @property
@@ -113,6 +114,7 @@ class DealsStream(HubspotStream):
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
+        params["associations"] = "contacts,companies,deals"
         return params
 
     @property
@@ -143,6 +145,7 @@ class ContactsStream(HubspotStream):
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
+        params["associations"] = "contacts,companies,deals"
         return params
 
     @property

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -102,7 +102,7 @@ class CompaniesStream(HubspotStream):
 
 class DealsStream(HubspotStream):
     """Define custom stream."""
-
+    _LOG_REQUEST_METRICS_URL=True
     name = "deals"
     path = "/crm/v3/objects/deals"
     primary_keys = ["id"]
@@ -133,7 +133,6 @@ class DealsStream(HubspotStream):
 
 class ContactsStream(HubspotStream):
     """Define custom stream."""
-
     name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -133,7 +133,7 @@ class DealsStream(HubspotStream):
 
 class ContactsStream(HubspotStream):
     """Define custom stream."""
-    
+
     name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -131,7 +131,7 @@ class DealsStream(HubspotStream):
             "deal_id": record["id"],
         }
     
-    def parse_response(self, response: Response) -> Iterable[dict]:
+    def parse_response(self, response) -> Iterable[dict]:
         self.logger.info(response)
         return super().parse_response(response)
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -114,7 +114,6 @@ class DealsStream(HubspotStream):
         params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
         params["associations"] = "contacts,companies,deals"
-        self.logger.info(params)
         return params
 
     @property

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -112,7 +112,7 @@ class DealsStream(HubspotStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        # params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
         params["associations"] = "contacts,companies,deals"
         self.logger.info(params)
@@ -130,6 +130,10 @@ class DealsStream(HubspotStream):
             "archived": record["archived"],
             "deal_id": record["id"],
         }
+    
+    def parse_response(self, response: Response) -> Iterable[dict]:
+        self.logger.info(response)
+        return super().parse_response(response)
 
 
 class ContactsStream(HubspotStream):

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -132,7 +132,7 @@ class DealsStream(HubspotStream):
         }
     
     def parse_response(self, response) -> Iterable[dict]:
-        self.logger.info(response)
+        self.logger.info(response.json()["results"])
         return super().parse_response(response)
 
 

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -102,6 +102,7 @@ class CompaniesStream(HubspotStream):
 
 class DealsStream(HubspotStream):
     """Define custom stream."""
+
     name = "deals"
     path = "/crm/v3/objects/deals"
     primary_keys = ["id"]
@@ -132,6 +133,7 @@ class DealsStream(HubspotStream):
 
 class ContactsStream(HubspotStream):
     """Define custom stream."""
+    
     name = "contacts"
     path = "/crm/v3/objects/contacts"
     primary_keys = ["id"]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -130,18 +130,6 @@ class DealsStream(HubspotStream):
             "archived": record["archived"],
             "deal_id": record["id"],
         }
-    
-    def parse_response(self, response) -> Iterable[dict]:
-        data = response.json()["results"]
-        for e in data:
-            self.logger.info("response")
-            self.logger.info(e.get("associations", ""))
-        return super().parse_response(response)
-
-    def post_process(self, row: dict, context) -> dict:
-        self.logger.info("post_process")
-        self.logger.info(row)
-        return super().post_process(row, context)
 
 
 class ContactsStream(HubspotStream):

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -138,7 +138,7 @@ class DealsStream(HubspotStream):
             self.logger.info(e.get("associations", ""))
         return super().parse_response(response)
 
-    def post_process(self, row: dict, context: dict | None) -> dict:
+    def post_process(self, row: dict, context) -> dict:
         self.logger.info("post_process")
         self.logger.info(row)
         return super().post_process(row, context)

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -115,6 +115,7 @@ class DealsStream(HubspotStream):
         params["properties"] = ",".join(self.properties)
         params["archived"] = context["archived"]
         params["associations"] = "contacts,companies,deals"
+        self.logger.info(params)
         return params
 
     @property


### PR DESCRIPTION
### Ticket ([DE-1717](https://potloc.atlassian.net/browse/DE-1717))

> Our API rate limit issues are almost solely based on the hubspot associations tables. 
> 
> We will need to replace these with a new version of the API, which allows us to *include associations directly in the base table*. See [here](https://developers.hubspot.com/docs/api/crm/deals): 
> 
> 
> !image-20230601-144231.png|width=1134,height=738!
> 
> The goal here would be to apply this new logic *strictly to the deals, companies and contacts tables.* We will be adding new associations in the future. 
> 
> This implies:
> 
> - Changing schemas in tap-Hubspot to accommodate for associations
> - Adding URL parameters to query this information
> - Adapting tables in hubspot-bigquery integrations to take new information
> - Removing sync for associations tables
> 
> 
> In order to ensure quick rollout, we should create new bigquery hubspot tables which *only have associations*. We can merge these with the existing hubspot tables until we have fully migrated to bigquery. 

---
_from `tiguidou` with :heart:_


[DE-1717]: https://potloc.atlassian.net/browse/DE-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ