### PR TITLE
Fix error due to large properties set

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -12,6 +12,8 @@ from singer_sdk.exceptions import RetriableAPIError
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.streams import RESTStream
 
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Union, cast
+
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 HUBSPOT_OBJECTS = [
     "deals",
@@ -252,3 +254,80 @@ class HubspotStream(RESTStream):
             on_backoff=self.backoff_handler,
         )(func)
         return decorator
+
+
+    def get_properties_chunks(self, all_records, batch_size):
+        result = []
+        for i in range(0, len(all_records), batch_size):
+            result.append(list(all_records[i:i + batch_size]))
+        return result
+        
+
+    def get_all_url_params(self, url_params: Iterable[dict], context: Optional[dict], next_page_token: Optional[Any]):
+
+        http_method = self.rest_method
+        url: str = self.get_url(context)
+        params: dict = url_params
+        request_data = self.prepare_request_payload(context, next_page_token)
+        headers = self.http_headers
+
+        authenticator = self.authenticator
+        if authenticator:
+            headers.update(authenticator.auth_headers or {})
+            params.update(authenticator.auth_params or {})
+
+        request = cast(
+            requests.PreparedRequest,
+            self.requests_session.prepare_request(
+                requests.Request(
+                    method=http_method,
+                    url=url,
+                    params=params,
+                    headers=headers,
+                    json=request_data,
+                ),
+            ),
+        )
+
+        return request
+    
+
+    def prepare_request(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> requests.PreparedRequest:
+        
+        all_url_params = self.get_url_params(context, next_page_token) 
+
+        if isinstance(all_url_params, types.GeneratorType):
+            for url_params in all_url_params:
+                request = self.get_all_url_params(url_params, context, next_page_token)
+                yield request
+        
+        else:
+            request = self.get_all_url_params(all_url_params, context, next_page_token)
+            yield request
+
+
+    def request_records(self, context: Optional[dict]) -> Iterable[dict]:
+        next_page_token: Any = None
+        finished = False
+        decorated_request = self.request_decorator(self._request)
+
+        while not finished:
+            get_prepared_request = self.prepare_request(
+                context, next_page_token=next_page_token
+            )
+            for prepared_request in get_prepared_request:
+                resp = decorated_request(prepared_request, context)
+                yield from self.parse_response(resp)
+            previous_token = copy.deepcopy(next_page_token)
+            next_page_token = self.get_next_page_token(
+                response=resp, previous_token=previous_token
+            )
+            if next_page_token and next_page_token == previous_token:
+                raise RuntimeError(
+                    f"Loop detected in pagination. "
+                    f"Pagination token {next_page_token} is identical to prior token."
+                )
+            # Cycle until get_next_page_token() no longer returns a value
+            finished = not next_page_token

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -109,6 +109,13 @@ class DealsStream(HubspotStream):
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
 
+        chunks = self.get_properties_chunks(all_properties, 300)
+        for chunk in chunks:
+            params["properties"] = ",".join(chunk)
+            params["archived"] = context["archived"]
+        
+            yield params
+    
     @property
     def schema(self) -> dict:
         if self.cached_schema is None:


### PR DESCRIPTION
When the list of properties is too large the API raises <FatalAPI ERROR
400>.
To fix this issue some of the methods in the main HubspotStream
class were overwritten to cover such cases by returning a generator
instead of the whole list. This way all the properties are passed in
batches.

# What was the issue


# How did we solve it


# Additional Notes / Warnings


# Fun fact (optional)
